### PR TITLE
Typo3 v10 Fix

### DIFF
--- a/Classes/Controller/BlockedIpController.php
+++ b/Classes/Controller/BlockedIpController.php
@@ -9,6 +9,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
 /**
  * BlockedIpController
  */
@@ -22,19 +24,26 @@ class BlockedIpController extends ActionController
     {
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('block_malicious_login_attempts');
         $failedLoginLimit = $extensionConfiguration["failedLoginLimit"];
+        $failedLoginTime = $extensionConfiguration["failedLoginTime"];
 
         // get all IP's that reached the limit
         $table = "tx_blockmaliciousloginattempts_failed_login";
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
-        $sql = "SELECT ip, COUNT(ip) as count, COUNT(ip) >= ".$failedLoginLimit." as blocked 
-                FROM tx_blockmaliciousloginattempts_failed_login 
-                WHERE 1=1 
-                GROUP BY ip
-                ORDER BY count DESC;";
-        $ipList = $queryBuilder->getConnection()->prepare($sql)->executeQuery()->fetchAll();
+        $queryBuilder->select('ip')
+            ->from($table)
+            ->addSelectLiteral('COUNT(ip) as count')
+            ->addSelectLiteral('COUNT(ip) >= "'.$failedLoginLimit.'" as blocked');
+        if($failedLoginTime > 0){
+            $queryBuilder->addSelectLiteral('count(CASE WHEN time BETWEEN "'.(time()-$failedLoginTime).'" AND "'.time().'" THEN 1 END) as timedFails');
+        }
+            
+        $queryBuilder->orderBy('count', 'DESC');
+
+        $ipList = $queryBuilder->groupBy('ip')->execute()->fetchAll();
 
         $this->view->assign("ipList", $ipList);
         $this->view->assign("failedLoginLimit", $failedLoginLimit);
+        $this->view->assign("failedLoginTime", $failedLoginTime);
         $this->view->assign("currentPage", "index");
     }
 

--- a/Classes/Controller/BlockedIpController.php
+++ b/Classes/Controller/BlockedIpController.php
@@ -23,7 +23,11 @@ class BlockedIpController extends ActionController
     {
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('block_malicious_login_attempts');
         $failedLoginLimit = $extensionConfiguration["failedLoginLimit"];
-        $failedLoginTime = $extensionConfiguration["failedLoginTime"];
+        
+        $failedLoginTime = 0;
+        if(isset($extensionConfiguration["failedLoginTime"])) {
+            $failedLoginTime = $extensionConfiguration["failedLoginTime"];
+        }
 
         // get all IP's that reached the limit
         $table = "tx_blockmaliciousloginattempts_failed_login";

--- a/Classes/Controller/BlockedIpController.php
+++ b/Classes/Controller/BlockedIpController.php
@@ -9,7 +9,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
-use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 /**
  * BlockedIpController

--- a/Resources/Private/Backend/Templates/BlockedIp/Index.html
+++ b/Resources/Private/Backend/Templates/BlockedIp/Index.html
@@ -29,6 +29,9 @@
         <p>
             The limit for failed login attempts per IP is set to {failedLoginLimit}.
         </p>
+        <f:if condition="{failedLoginTime}">
+            The age limit for failed login attempts is set to {failedLoginTime} seconds.
+        </f:if>
     </div>
 </f:section>
 
@@ -38,16 +41,39 @@
             <th>#</th>
             <th>IP</th>
             <th>Failed login attempts</th>
+            <f:if condition="{failedLoginTime}">
+                <th>Failed login attempts within timelimit</th>
+            </f:if>
             <th>Status</th>
             <th>Action</th>
         </tr>
+
         <f:for each="{ipList}" as="item" iteration="i">
+
+            <f:variable name="itemIsBlocked" value="{item.blocked}" />
+            <f:if condition="{failedLoginTime}">
+                <f:then>
+                    <f:if condition="{item.timedFails} >= {failedLoginLimit}">
+                        <f:then>
+                            <f:variable name="itemIsBlocked" value="1" />
+                        </f:then>
+                        <f:else>
+                            <f:variable name="itemIsBlocked" value="0" />
+                        </f:else>
+                        
+                    </f:if>
+                </f:then>
+            </f:if>
+
             <tr>
                 <td>{i.cycle}</td>
                 <td>{item.ip}</td>
                 <td>{item.count}</td>
+                <f:if condition="{failedLoginTime}">
+                    <td>{item.timedFails}</td>
+                </f:if>
                 <td>
-                    <f:if condition="{item.blocked}">
+                    <f:if condition="{itemIsBlocked}">
                         <f:then>
                             <span class="badge badge-danger">blocked</span>
                         </f:then>
@@ -57,7 +83,7 @@
                     </f:if>
                 </td>
                 <td>
-                    <f:if condition="{item.blocked}">
+                    <f:if condition="{itemIsBlocked}">
                         <f:then>
                             <f:link.action class="btn btn-danger" action="unblock" arguments="{ip: item.ip}">
                                 unblock

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,5 +2,8 @@
 # cat=basic/enable/050; type=int; label=Number of allowed login attempts before access gets blocked
 failedLoginLimit = 3
 
+# cat=basic/enable/050; type=int; label=Max IP age, 0 to block forever
+failedLoginTime = 0
+
 # cat=basic/enable/050; type=string; label=Message when login is locked
 lockMessage = Your IP address ({ip_address}) has been blocked. Contact your website administration.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,5 @@
+<?php
+
+defined('TYPO3') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(file_get_contents(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('block_malicious_login_attempts', 'Configuration/TypoScript/setup.typoscript')));


### PR DESCRIPTION
See https://github.com/cepheiVV/block_malicious_login_attempts/issues/1

Before typo3 v11.5 there was/is no `executeQuery` method.
> Changed in version 11.5: The widely used function ->execute() has been split into the methods executeQuery and executeStatement(). executeQuery returns a \Doctrine\DBAL\Result instead of a \Doctrine\DBAL\Statement.
Source: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#execute-executequery-and-executestatement

Also i added a time-based ban option.

The please test this on the other supported typo3 version.